### PR TITLE
Support for http connections to FortiGate hosts

### DIFF
--- a/fortigate_api/fortigate.py
+++ b/fortigate_api/fortigate.py
@@ -72,6 +72,8 @@ class Fortigate:
         """Returns URL to Fortigate"""
         if self.port == 443:
             return f"https://{self.host}"
+        elif self.port == 80:
+            return f"http://{self.host}"
         return f"https://{self.host}:{self.port}"
 
     # =========================== methods ============================


### PR DESCRIPTION
Hi @vladimirs-git 
for enabling http support, I have added the to following lines.
This would be especially useful in test environments, where FortiGate VMs without a licence only support http connections.