### PR TITLE
python 3.10.5 pip install fails on not installing 'requests' before usage #3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "fortigate-api"
+version = "0.2.5"
+description = "Python package to configure Fortigate (Fortios) devices using REST API"
+authors = ["Vladimir Prusakov <vladimir.prusakovs@gmail.com>"]
+readme = "README.rst"
+packages = [{include = "fortigate_api"}]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+certifi = "2022.5.18.1"
+charset-normalizer = "2.0.12"
+idna = "3.3"
+requests = "2.28.*"
+urllib3 = "1.26.9"
+
+[tool.poetry.dev-dependencies]
+mypy = "^0.*"
+pylint = "^2.13.*"
+pytest = "^7.1.*"
+restructuredtext-lint = "^1.4.*"
+twine = "^4.0.*"
+types-requests = "^2.27.*"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,27 +1,45 @@
-[tool.poetry]
-name = "fortigate-api"
+[project]
+name = "fortigate_api"
 version = "0.2.5"
+authors = [
+  { name="Vladimir Prusakov", email="vladimir.prusakovs@gmail.com" },
+]
 description = "Python package to configure Fortigate (Fortios) devices using REST API"
-authors = ["Vladimir Prusakov <vladimir.prusakovs@gmail.com>"]
 readme = "README.rst"
-packages = [{include = "fortigate_api"}]
+license = { text="MIT" }
+requires-python = ">=3.8"
+dependencies = [
+    'certifi == 2022.5.18.1',
+    'charset-normalizer = 2.0.12',
+    'idna = 3.3',
+    'requests ~= 2.28',
+    'urllib3 = 1.26.9',
+]
+keywords = ["fortigate, api, fortios, firewall, networking, telecommunication"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Intended Audience :: Telecommunications Industry",
+    # "Operating System :: FortiOS",
+    "Topic :: System :: Networking :: Firewalls",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.8",
+    "Natural Language :: English",
+]
 
-[tool.poetry.dependencies]
-python = "^3.8"
-certifi = "2022.5.18.1"
-charset-normalizer = "2.0.12"
-idna = "3.3"
-requests = "2.28.*"
-urllib3 = "1.26.9"
+[project.urls]
+"Homepage" = "https://github.com/vladimirs-git/fortigate-api"
+"Repository" = "https://github.com/vladimirs-git/fortigate-api"
+"Bug Tracker" = "https://github.com/vladimirs-git/fortigate-api/issues"
+"Download URL" = "https://github.com/vladimirs-git/fortigate-api/archive/refs/tags/0.2.5.tar.gz"
 
-[tool.poetry.dev-dependencies]
-mypy = "^0.*"
-pylint = "^2.13.*"
-pytest = "^7.1.*"
-restructuredtext-lint = "^1.4.*"
-twine = "^4.0.*"
-types-requests = "^2.27.*"
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+[project.optional-dependencies]
+dev = [
+    'mypy < 1',
+    'pylint ~= 2.13',
+    'pytest ~= 7.1',
+    'restructuredtext-lint ~= 1.4',
+    'twine ~= 4.0',
+    'types-requests ~= 2.27'
+]


### PR DESCRIPTION
With the pyproject.toml in place python3.10.5 successfully installs the fortigate-api module, including the requests module.

Within a fresh venv in the cloned fortigate-api directory:

```
$ pip install -e .
Obtaining file:///home/bdorlandt-t1/tmp/fortigate-api
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Collecting certifi==2022.5.18.1
  Using cached certifi-2022.5.18.1-py3-none-any.whl (155 kB)
Requirement already satisfied: setuptools<64.0.0,>=63.3.0 in ./venv/lib/python3.10/site-packages (from fortigate-api==0.2.5) (63.3.0)
Collecting idna==3.3
  Using cached idna-3.3-py3-none-any.whl (61 kB)
Collecting urllib3==1.26.9
  Using cached urllib3-1.26.9-py2.py3-none-any.whl (138 kB)
Collecting requests<2.29.0,>=2.28.0
  Using cached requests-2.28.1-py3-none-any.whl (62 kB)
Collecting charset-normalizer==2.0.12
  Using cached charset_normalizer-2.0.12-py3-none-any.whl (39 kB)
Building wheels for collected packages: fortigate-api
  Building editable for fortigate-api (pyproject.toml) ... done
  Created wheel for fortigate-api: filename=fortigate_api-0.2.5-py3-none-any.whl size=8390 sha256=466fc1ad173cd7027cab7088a2c92797386583c7a090f0908e16970c756eda23
  Stored in directory: /tmp/pip-ephem-wheel-cache-hc725m72/wheels/16/f0/fd/b33fa9dec273d18687cca29ba41da79d6aa3795fbeaf70f663
Successfully built fortigate-api
Installing collected packages: urllib3, idna, charset-normalizer, certifi, requests, fortigate-api
Successfully installed certifi-2022.5.18.1 charset-normalizer-2.0.12 fortigate-api-0.2.5 idna-3.3 requests-2.28.1 urllib3-1.26.9
```

```
$ pip freeze
certifi==2022.5.18.1
charset-normalizer==2.0.12
-e git+https://github.com/vladimirs-git/fortigate-api.git@476827e352b3aef7ab540b908247d2fbc47d91b1#egg=fortigate_api
idna==3.3
requests==2.28.1
urllib3==1.26.9
```

```
$ pip -V                                                                                                                                                                                   1 ↵
pip 22.2.1 from /home/bdorlandt-t1/tmp/fortigate-api/venv/lib/python3.10/site-packages/pip (python 3.10)
$ python3 -V
Python 3.10.5
```

# Before, without the pyproject.toml

```
$ pip install -e .
Obtaining file:///home/bdorlandt-t1/tmp/fortigate-api
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [10 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/home/bdorlandt-t1/tmp/fortigate-api/setup.py", line 7, in <module>
          import fortigate_api as package
        File "/home/bdorlandt-t1/tmp/fortigate-api/fortigate_api/__init__.py", line 3, in <module>
          from fortigate_api.fortigate import Fortigate
        File "/home/bdorlandt-t1/tmp/fortigate-api/fortigate_api/fortigate.py", line 12, in <module>
          import requests
      ModuleNotFoundError: No module named 'requests'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

I have no experience yet with combining it with pypi and if the setup.py can be replaced.


