### PR TITLE
Support the new authentication cookie format ccsrftoken_443_3334d10

### DIFF
--- a/fortigate_api/fortigate.py
+++ b/fortigate_api/fortigate.py
@@ -202,7 +202,7 @@ class Fortigate:
         cookie_name = "ccsrftoken"
         cookies = [o for o in session.cookies if o and o.name == cookie_name]
         if not cookies:
-            regex = cookie_name + r"_\d+$"
+            regex = cookie_name + r".*$"
             cookies = [o for o in session.cookies if re.match(regex, o.name)]
         cookies = [o for o in cookies if isinstance(o.value, str)]
         if not cookies:


### PR DESCRIPTION
The cookie name has changed from `ccsrftoken_443` to `ccsrftoken_443_3334d10`, and given that it seems to be changing every version, allow any cookie that starts with ccsrftoken. 