### PR TITLE
fix token validation link

### DIFF
--- a/fortigate_api/fortigate_base.py
+++ b/fortigate_api/fortigate_base.py
@@ -144,7 +144,7 @@ class FortiGateBase:
         if self.token:
             try:
                 response: Response = session.get(
-                    url=f"{self.url}/api/v2/cmdb/system/status",
+                    url=f"{self.url}/monitor/v2/cmdb/system/status",
                     headers=self._bearer_token(),
                     verify=self.verify,
                 )


### PR DESCRIPTION
The current validation link for the token check uses an incorrect link. 
Newer FortiOS might discontinue sending HTTP 200 responses with no content to this request.
